### PR TITLE
adjust time reporting hydrographs

### DIFF
--- a/model/lisReportfile.cpp
+++ b/model/lisReportfile.cpp
@@ -684,7 +684,7 @@ void TWorld::ReportTimeseriesCSV(void)
             out << "\n";
 
             // second row, units
-            out << "min"; //time
+            out << "days"; //time
             if (SwitchRainfall) out << ",mm/h"; //rain
             if (SwitchSnowmelt) out << ",mm/h"; // snow
             out << "," << unitS; // qall
@@ -719,7 +719,7 @@ void TWorld::ReportTimeseriesCSV(void)
         QTextStream out(&fout);
         out.setFieldWidth(width);
         out.setRealNumberNotation(QTextStream::FixedNotation);
-        out.setRealNumberPrecision(5);
+        out.setRealNumberPrecision(7);
 
         out << (time/60)/1440.0;
 


### PR DESCRIPTION
when recalculating reported time to a timestamp, more digits are required to prevent rounding errors in the seconds.