### PR TITLE
Added option to load baseflow map with precalculated values

### DIFF
--- a/channel/lisChannelflow.cpp
+++ b/channel/lisChannelflow.cpp
@@ -96,6 +96,11 @@ void TWorld::ChannelBaseflow(void)
     // add a stationary part
     if(SwitchChannelBaseflowStationary)
     {
+        // add switch for baseflow as map
+        // if added as map then addedbaseflow = true;
+        if (SwitchChannelBaseflowMap)
+            addedbaseflow = true;
+
         // first time
         if(!addedbaseflow) {
            #pragma omp parallel for num_threads(userCores)

--- a/include/model.h
+++ b/include/model.h
@@ -446,6 +446,7 @@ public:
         // channel and Overland flow
         SwitchIncludeChannel,
         SwitchChannelBaseflowStationary,
+        SwitchChannelBaseflowMap,
         SwitchChannelInfil,
         SwitchGWflow,
         SwitchGW2Dflow,

--- a/include/version.h
+++ b/include/version.h
@@ -37,8 +37,8 @@
 #define VERSION_H_
 
 
-#define VERSIONNR "7.4.7.beta.R7"
-#define VERSIONDATE "2025/07/13"
+#define VERSIONNR "7.4.7.beta.R8"
+#define VERSIONDATE "2025/08/21"
 
 #define VERSION QString("openLISEM version %1 - %2").arg(VERSIONNR).arg(VERSIONDATE)
 

--- a/model/lisDataInit.cpp
+++ b/model/lisDataInit.cpp
@@ -1118,6 +1118,13 @@ Fill(*tma,0);
         }
     }
 
+    // baseflow map
+    if (SwitchChannelBaseflowMap)
+        {
+        BaseFlowInflow = ReadMap(LDD, getvaluename("baseflow_inflow"));
+        BaseFlowDischarges = ReadMap(LDD, getvaluename("baseflow")); // in this case we don't need this map, but without loading LISEM doesn't run.
+    }
+
     if(SwitchErosion) {
         TotalChanDetMap = NewMap(0);
         TotalChanDepMap = NewMap(0);
@@ -1832,7 +1839,8 @@ void TWorld::IntializeData(void)
     // SwitchUseMaterialDepth not active!
     SwitchUseMaterialDepth = false;
 
-    if (SwitchChannelBaseflowStationary)
+    // add switch if baseflow map added, don't calculate new.
+    if (SwitchChannelBaseflowStationary && !SwitchChannelBaseflowMap)
         FindStationaryBaseFlow();
 
 }
@@ -1949,6 +1957,7 @@ void TWorld::IntializeOptions(void)
     SwitchLDDGWflow = false;
     SwitchSWATGWflow = false;
     SwitchChannelBaseflowStationary = false;
+    SwitchChannelBaseflowMap = false;
     SwitchChannelInfil = false;
     SwitchCulverts = false;
     SwitchDischargeUser = false;

--- a/model/lisDataInit.cpp
+++ b/model/lisDataInit.cpp
@@ -1121,7 +1121,7 @@ Fill(*tma,0);
     // baseflow map
     if (SwitchChannelBaseflowMap)
         {
-        BaseFlowInflow = ReadMap(LDD, getvaluename("baseflow_inflow"));
+        BaseFlowInflow = ReadMap(LDD, getvaluename("baseflow"));
         BaseFlowDischarges = ReadMap(LDD, getvaluename("baseflow")); // in this case we don't need this map, but without loading LISEM doesn't run.
     }
 

--- a/model/lisRunfile.cpp
+++ b/model/lisRunfile.cpp
@@ -263,6 +263,7 @@ void TWorld::ParseRunfileData(void)
         if (p1.compare("Include main channels")==0)             SwitchIncludeChannel = iii == 1;
         if (p1.compare("Include channel infil")==0)             SwitchChannelInfil   = iii == 1;
         if (p1.compare("Include stationary baseflow")==0)       SwitchChannelBaseflowStationary  = iii == 1;
+        if (p1.compare("Stationary baseflow as map")==0)        SwitchChannelBaseflowMap  = iii == 1;
       //  if (p1.compare("Adjust channel crosssection")==0)       SwitchChannelAdjustCHW  = iii == 1;
         if (p1.compare("Include channel culverts")==0)          SwitchCulverts  = iii == 1;
         if (p1.compare("Include channel inflow")==0)            SwitchDischargeUser  = iii == 1;
@@ -398,11 +399,13 @@ void TWorld::ParseRunfileData(void)
     {
       //  SwitchChannelBaseflow = false;
         SwitchChannelBaseflowStationary = false;
+        SwitchChannelBaseflowMap = false;
         SwitchChannelInfil = false;
     } else {
         if (SwitchChannelInfil) {
          //   SwitchChannelBaseflow = false;
             SwitchChannelBaseflowStationary = false;
+            SwitchChannelBaseflowMap = false;
         }
     }
 

--- a/ui_full/LisUIDefaultNames.cpp
+++ b/ui_full/LisUIDefaultNames.cpp
@@ -118,6 +118,7 @@ void lisemqt::DefaultMapnames()
     DEFmaps.append("2;QinPoints;QinPoints.map;Locations in channel network where discharge is added from a text record. Unique nr > 0;qinpoints");
     DEFmaps.append("2;Cohesion;chancoh.map;Cohesion of channel bed (kPa);chancoh");
     DEFmaps.append("2;Stationary baseflow;baseflow.map;Stationary baseflow maintained in the run (m3/s at the outlet);baseflow");
+    DEFmaps.append("2;Calculated baseflow;baseflow_inflow.map;Stationary baseflow maintained in the run (m3/s for each cell with baseflow;baseflow_inflow");
     DEFmaps.append("2;Baseflow network;lddgroundwater.map;LDD perpendicular to the river;lddbase");
     DEFmaps.append("2;Baseflow contrib. area;gwdistance.map;Distance to river (m);basereach");
     DEFmaps.append("2;WHInit;WHinit.map;Initial floodlevel (m);whinit");
@@ -438,6 +439,8 @@ void lisemqt::defaultRunFile()
     namelist[i++].name = QString("Include channel infil");
     namelist[i].value = QString("0");
     namelist[i++].name = QString("Include stationary baseflow");
+    namelist[i].value = QString("0");
+    namelist[i++].name = QString("Stationary baseflow as map");
     namelist[i].value = QString("0");
     namelist[i++].name = QString("Include channel culverts");
     namelist[i].value = QString("0");

--- a/ui_full/LisUIDefaultNames.cpp
+++ b/ui_full/LisUIDefaultNames.cpp
@@ -118,7 +118,7 @@ void lisemqt::DefaultMapnames()
     DEFmaps.append("2;QinPoints;QinPoints.map;Locations in channel network where discharge is added from a text record. Unique nr > 0;qinpoints");
     DEFmaps.append("2;Cohesion;chancoh.map;Cohesion of channel bed (kPa);chancoh");
     DEFmaps.append("2;Stationary baseflow;baseflow.map;Stationary baseflow maintained in the run (m3/s at the outlet);baseflow");
-    DEFmaps.append("2;Calculated baseflow;baseflow_inflow.map;Stationary baseflow maintained in the run (m3/s for each cell with baseflow;baseflow_inflow");
+    //DEFmaps.append("2;Calculated baseflow;baseflow_inflow.map;Stationary baseflow maintained in the run (m3/s for each cell with baseflow;baseflow_inflow");
     DEFmaps.append("2;Baseflow network;lddgroundwater.map;LDD perpendicular to the river;lddbase");
     DEFmaps.append("2;Baseflow contrib. area;gwdistance.map;Distance to river (m);basereach");
     DEFmaps.append("2;WHInit;WHinit.map;Initial floodlevel (m);whinit");

--- a/ui_full/LisUIrunfile.cpp
+++ b/ui_full/LisUIrunfile.cpp
@@ -246,6 +246,7 @@ void lisemqt::ParseInputData()
         if (p1.compare("Include main channels")==0)          checkIncludeChannel->setChecked(check);
         if (p1.compare("Include channel infil")==0)          checkChannelInfil->setChecked(check);
         if (p1.compare("Include stationary baseflow")==0)    checkStationaryBaseflow->setChecked(check);
+        //if (p1.compare("Stationary baseflow as map")==0)     checkStationaryBaseflowMap->setChecked(check);
         if (p1.compare("Include channel culverts")==0)       checkChannelCulverts->setChecked(check);
         if (p1.compare("Include channel inflow")==0)         checkDischargeUser->setChecked(check);
         if (p1.compare("Include water height inflow")==0)    checkWaterUserIn->setChecked(check);
@@ -867,6 +868,7 @@ void lisemqt::updateModelData()
         if (p1.compare("Include main channels")==0)          namelist[j].value.setNum((int)checkIncludeChannel->isChecked());
         if (p1.compare("Include channel infil")==0)          namelist[j].value.setNum((int)checkChannelInfil->isChecked());
         if (p1.compare("Include stationary baseflow")==0)    namelist[j].value.setNum((int)checkStationaryBaseflow->isChecked());
+      //  if (p1.compare("Stationary baseflow as map")==0)     namelist[j].value.setNum((int)checkStationaryBaseflowMap->isChecked());
         if (p1.compare("Include channel culverts")==0)       namelist[j].value.setNum((int)checkChannelCulverts->isChecked());
         if (p1.compare("Include channel inflow")==0)         namelist[j].value.setNum((int)checkDischargeUser->isChecked());
         if (p1.compare("Include water height inflow")==0)    namelist[j].value.setNum((int)checkWaterUserIn->isChecked());


### PR DESCRIPTION
In some case not all channels/streams contain a baseflow. This adjustments add an option to load a precaluclated baseflow map, so some channels can have base flow and other not. Currently the option is only added in the runfile and not in the GUI.