### PR TITLE
No outflow from pits strom drains

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ The model can be downloaded from:
 https://github.com/vjetten/openlisem/releases/tag/lisem_bin
 
 ============
-Date: 250713
+Date: 250901
 ============
 
 This software is under the copyright model GPLv3 (distributed with the model) and subject to additional disclaimers.
@@ -14,6 +14,10 @@ For questions contact v.g.jetten AD utwente.nl
 NOTE: only a 64bit version exists, 32 bit is not supported
 NOTE: The code since version 5.6 is compilable under linux (checked for Ubuntu, update version 7.2)
 NOTE: since version 6.x it is fully parallel and developed with MSYS2.0, Qt6.x.x, openmp, gdal and (minimal) pcraster
+
+250901 - v7.4.7.beta.R8
+- Added: option to load stationary baseflow as precalculated map
+- Added: water flowing into urban storm drains does not dissapear but fills up the storm drains, when full the stormdrains will overflow.
 
 250713 - v7.4.7.beta.R1-R7
 - CHHANGED: read all maps as float (4 byte) instead of double (8 byte), save 40-50% RAM use

--- a/channel/lisChannelflow.cpp
+++ b/channel/lisChannelflow.cpp
@@ -98,8 +98,8 @@ void TWorld::ChannelBaseflow(void)
     {
         // add switch for baseflow as map
         // if added as map then addedbaseflow = true;
-        if (SwitchChannelBaseflowMap)
-            addedbaseflow = true;
+        //if (SwitchChannelBaseflowMap)
+       //     addedbaseflow = true;
 
         // first time
         if(!addedbaseflow) {

--- a/flow/lisTiledrainflow.cpp
+++ b/flow/lisTiledrainflow.cpp
@@ -192,6 +192,7 @@ void TWorld::TileFlow(void)
         tmc->Drc = Qin;
 
         TileQn->Drc = IterateToQnew(Qin, TileQ->Drc, TileAlpha->Drc, _dt, DX->Drc, TileMaxQ->Drc, TileMaxAlpha->Drc);
+        // if LDDTile->Drc == 5 then block flow - done in LisDataInit.cpp
         TileQn->Drc = qMin(Qin+TileWaterVol->Drc/_dt, TileQn->Drc);
         TileQn->Drc = qMin(TileQn->Drc, TileMaxQ->Drc);
     }
@@ -204,13 +205,13 @@ void TWorld::TileFlow(void)
             full+=1;
         //TileWaterVol->Drc = qMin(TileWaterVol->Drc, TileArea->Drc*DX->Drc);
         // gives always MB errors!
-        //if (LDDTile->Drc == 5)
-          //  totq = TileQn->Drc*_dt;
+       // if (LDDTile->Drc == 5)
+       //     totq = TileQn->Drc*_dt;
     }}
 
     // check if no MB loss in this function
-    //double tot1 = MapTotal(*TileWaterVol);
-    //qDebug() << tot << tot1 << totq << tot-tot1-totq << full << MB;
+  //  double tot1 = MapTotal(*TileWaterVol);
+  //  qDebug() << tot << tot1 << totq << tot-tot1-totq << full << MB;
 
 }
 

--- a/include/version.h
+++ b/include/version.h
@@ -38,7 +38,7 @@
 
 
 #define VERSIONNR "7.4.7.beta.R8"
-#define VERSIONDATE "2025/08/21"
+#define VERSIONDATE "2025/09/01"
 
 #define VERSION QString("openLISEM version %1 - %2").arg(VERSIONNR).arg(VERSIONDATE)
 

--- a/model/lisDataInit.cpp
+++ b/model/lisDataInit.cpp
@@ -1123,6 +1123,7 @@ Fill(*tma,0);
         {
         BaseFlowInflow = ReadMap(LDD, getvaluename("baseflow"));
         BaseFlowDischarges = ReadMap(LDD, getvaluename("baseflow")); // in this case we don't need this map, but without loading LISEM doesn't run.
+        BaseFlowInitialVolume = ReadMap(LDD, getvaluename("baseflowinitvol")); // in m3
     }
 
     if(SwitchErosion) {

--- a/model/lisDataInit.cpp
+++ b/model/lisDataInit.cpp
@@ -1840,9 +1840,14 @@ void TWorld::IntializeData(void)
     // SwitchUseMaterialDepth not active!
     SwitchUseMaterialDepth = false;
 
-    // add switch if baseflow map added, don't calculate new.
+    // add switch if baseflow map added, don't calculate new. 
     if (SwitchChannelBaseflowStationary && !SwitchChannelBaseflowMap)
         FindStationaryBaseFlow();
+
+    // in case of baseflow map, add initial volume from precalculated map
+    if (SwitchChannelBaseflowMap)
+        BaseFlowInit = MapTotal(*BaseFlowInitialVolume);
+        // correct mass balance
 
 }
 //---------------------------------------------------------------------------

--- a/model/lisDataInit.cpp
+++ b/model/lisDataInit.cpp
@@ -2330,6 +2330,11 @@ void TWorld::InitTiledrains(void)
                 TileMaxAlpha->Drc  = TileArea->Drc/std::pow(TileMaxQ->Drc, BETArect);
             }}
         }
+
+        FOR_ROW_COL_MV_TILEL {
+            if (LDDTile->Drc == 5)
+                TileMaxQ->Drc = 1e-6; //No outflow from tiledrains
+        }}
     }
 }
 //---------------------------------------------------------------------------

--- a/model/lisTotalsMB.cpp
+++ b/model/lisTotalsMB.cpp
@@ -542,7 +542,7 @@ void TWorld::MassBalance()
     // floodBoundaryTot is already in Qtot
     MB = waterin > 0 ? (waterin - waterout - waterstore)/waterin*100  : 0;
 
-   // qDebug() << RainTot << IntercTot << IntercHouseTot << InfilTot  << WaterVolTot << ChannelVolTot <<  Qtot ;
+    // qDebug() << RainTot << IntercTot << IntercHouseTot << InfilTot  << WaterVolTot << ChannelVolTot <<  Qtot ;
 
     Fill(*MBm, 0);
 

--- a/ui_full/LisUIDefaultNames.cpp
+++ b/ui_full/LisUIDefaultNames.cpp
@@ -118,7 +118,7 @@ void lisemqt::DefaultMapnames()
     DEFmaps.append("2;QinPoints;QinPoints.map;Locations in channel network where discharge is added from a text record. Unique nr > 0;qinpoints");
     DEFmaps.append("2;Cohesion;chancoh.map;Cohesion of channel bed (kPa);chancoh");
     DEFmaps.append("2;Stationary baseflow;baseflow.map;Stationary baseflow maintained in the run (m3/s at the outlet);baseflow");
-    //DEFmaps.append("2;Calculated baseflow;baseflow_inflow.map;Stationary baseflow maintained in the run (m3/s for each cell with baseflow;baseflow_inflow");
+    DEFmaps.append("2;Initial volume baseflow;baseflowinitvol.map;Initial volume of water in channels when baseflow is provided as map;baseflowinitvol");
     DEFmaps.append("2;Baseflow network;lddgroundwater.map;LDD perpendicular to the river;lddbase");
     DEFmaps.append("2;Baseflow contrib. area;gwdistance.map;Distance to river (m);basereach");
     DEFmaps.append("2;WHInit;WHinit.map;Initial floodlevel (m);whinit");


### PR DESCRIPTION
This includes 2 main updates:
- The stromdrain pits (LDDtile =5) are now closed, so the storm drains fill up. If needed this can be switched on or of in the runfile - but that is not yet included in the code.
- The baseflow as map caused MB errors, this is solved by adding the initial baseflow volume.